### PR TITLE
.travis.yml Expansion for Arch Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
   
 install:
     # Use the following commands one after the other to install everything on Arch using Pacaur:
-    # $ sudo pacman -S git qt5-base qt5-multimedia go python2 mesa && 
-    # $ pacaur -y lcov gcc49 && 
+    # $ sudo pacman -S git qt5-base qt5-multimedia go python2 mesa gcc && 
+    # $ pacaur -y lcov && 
     # $ gem install coveralls-lcov
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     eval "$(gimme 1.6)";

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ before_install:
   - export CXX="g++-4.9"
   
 install:
+    # Use the following commands one after the other to install everything on Arch using Pacaur:
+    # $ sudo pacman -S git qt5-base qt5-multimedia go python2 mesa && 
+    # $ pacaur -y lcov gcc49 && 
+    # $ gem install coveralls-lcov
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     eval "$(gimme 1.6)";
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;


### PR DESCRIPTION
Broken up into multiple lines because the whole command would break readability.

g++-4.9/gcc-4.9 isn't maintained on the AUR. Currently fails into error loop on build.

GCC (gcc-7.1.1) compiles Griefly without error. 

libglu1-mesa-dev is included under mesa.