### PR TITLE
FIX: Competing namespaces for abs

### DIFF
--- a/sources/client/representation/Representation.cpp
+++ b/sources/client/representation/Representation.cpp
@@ -398,7 +398,7 @@ int GetPixelSpeedForDistance(int distance)
         return 0;
     }
 
-    distance = std::abs(distance);
+    distance = abs(distance);
 
     return sign * (((distance - 1) / 8) + 1);
 }


### PR DESCRIPTION
Compiling with Clang 5.0.1 on OpenBSD fails on `Representation.cpp`:

```
/home/gaddox/Documents/griefly/sources/client/representation/Representation.cpp:401:16: error: call to 'abs' is ambiguous
    distance = std::abs(distance);
```

This is likely due to operator overloading on `abs`, in `cmath` and `stdlib.h`. Removing the namespace here forces the `stdlib.h` interpretation of `abs`. `distance` is an int so using the C-style `abs` is fine. 

Otherwise, after changing the default Qt5 cmake path, Griefly compiles on OpenBSD 6.3 with Clang 5.0.1.