### PR TITLE
FIX: FastIsType.h improperly checking for MSVC

### DIFF
--- a/sources/core/FastIsType.h
+++ b/sources/core/FastIsType.h
@@ -5,7 +5,7 @@
 
 #include <kvengine_export.h>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if !defined(_MSC_VER)
 #define __forceinline __attribute__((always_inline)) inline
 #endif
 


### PR DESCRIPTION
Checking for a `_MSC_VER` instead would cover all but one edge case.

Fixes "no matching function call to FastIsType" on OpenBSD.