### PR TITLE
FIX: Clang namespace ambiguities

### DIFF
--- a/sources/client/representation/Representation.cpp
+++ b/sources/client/representation/Representation.cpp
@@ -18,6 +18,8 @@
 #include <QMutexLocker>
 #include <QCoreApplication>
 
+#include <cstdlib>
+
 namespace
 {
 


### PR DESCRIPTION
Update of: 

FIX: Competing namespaces for abs #500

