### PR TITLE
FIX: Improper griefly-server log formatting

### DIFF
--- a/gopath/src/griefly-server/main.go
+++ b/gopath/src/griefly-server/main.go
@@ -44,6 +44,6 @@ func main() {
 
 	err = ListenAndServe(*listen, registry, collector)
 	if err != nil {
-		log.Fatal("main: error listening on", *listen, err)
+		log.Fatal("main: error listening on ", *listen, " ", err)
 	}
 }


### PR DESCRIPTION
Before:
```
2018/08/08 15:12:36 main: error listening on:1111listen tcp :1111: bind: address already in use
```

After:
```
2018/08/08 15:12:36 main: error listening on :1111 listen tcp :1111: bind: address already in use
```