### PR TITLE
Sort input file list

### DIFF
--- a/utils/metadata_generator.py
+++ b/utils/metadata_generator.py
@@ -85,6 +85,8 @@ def metadata_to_json(metadata: Dict[str, List]) -> str:
 def generate_metadata(directory: str) -> List[dict]:
     result = []
     for directory, directory_names, filenames in os.walk(directory):
+        directory_names.sort()
+        filenames.sort()
         for filename in [f for f in filenames if f.endswith(".h")]:
             full_path = os.path.join(directory, filename)
             if "KvMacros.h" not in full_path:


### PR DESCRIPTION
Sort input file list
so that metadata.json and KVEngine build in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.